### PR TITLE
support command line arguments for onedrive configuration

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -12,6 +12,23 @@ int main(int argc, char *argv[])
     QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 
     QApplication app(argc, argv);
+    QCoreApplication::setApplicationName("onedrive-systray");
+
+    QCommandLineParser parser;
+    parser.setApplicationDescription("Run and control OneDrive from the system tray");
+    parser.addHelpOption();
+    QCommandLineOption onedrivePathOption(QStringList() << "p" << "onedrive-path",
+		    "Path to the OneDrive program", "path");
+    parser.addOption(onedrivePathOption);
+    QCommandLineOption onedriveArgsOption(QStringList() << "a" << "onedrive-args",
+		    "Arguments passed to OneDrive", "args");
+    parser.addOption(onedriveArgsOption);
+
+    parser.process(app);
+
+    QString onedrivePath = parser.value(onedrivePathOption);
+    QString onedriveArgs = parser.value(onedriveArgsOption);
+
 
     if (!QSystemTrayIcon::isSystemTrayAvailable()) {
         QMessageBox::critical(0, QObject::tr("Systray"), QObject::tr("I couldn't detect any system tray on this system."));
@@ -19,7 +36,7 @@ int main(int argc, char *argv[])
     }
     QApplication::setQuitOnLastWindowClosed(false);
 
-    Window window;
+    Window window(onedrivePath, onedriveArgs);
     //window.show();
     return app.exec();
 }

--- a/window.cpp
+++ b/window.cpp
@@ -8,6 +8,7 @@
 #include <QComboBox>
 #include <QCoreApplication>
 #include <QCloseEvent>
+#include <QDebug>
 #include <QGroupBox>
 #include <QLabel>
 #include <QLineEdit>
@@ -18,7 +19,7 @@
 #include <QMessageBox>
 #include <QFrame>
 
-Window::Window()
+Window::Window(QString onedrive_path, QString onedrive_arguments)
 {
     ConfigurationWindow = new Window_1;
 
@@ -35,22 +36,31 @@ Window::Window()
     mainLayout->addWidget(messageGroupBox);
     setLayout(mainLayout);
 
-    execute();
+    execute(onedrive_path, onedrive_arguments);
 
     setWindowTitle(tr("Systray"));
     resize(400, 300);
 }
 
 // ********** Block to execute external program ********** //
-void Window::execute()
+void Window::execute(QString onedrive_path, QString onedrive_arguments)
 {
     process = new QProcess();
     //QStringList arguments{"--monitor", "--verbose", "--confdir", "/home/daniel/.config/onedrive"};
-    QStringList arguments{"--monitor", "--local-first", "--skip-symlinks", "--confdir", "/home/daniel/.config/onedrive"};
+    // QStringList arguments{"--monitor", "--local-first", "--skip-symlinks", "--confdir", "/home/daniel/.config/onedrive"};
 
-    QString program("/usr/local/bin/onedrive");
+    if (onedrive_path.isEmpty()) {
+	    onedrive_path = QString("onedrive");
+    }
+    if (onedrive_arguments.isEmpty()) {
+	    onedrive_arguments = QString("--monitor");
+    }
+    
+    qDebug() << "Selected onedrive path: " << onedrive_path;
+    qDebug() << "Selected onedrive args: " << onedrive_arguments;
 
-    process->setProgram(program);
+    QStringList arguments = onedrive_arguments.split(" ", QString::SkipEmptyParts);
+    process->setProgram(onedrive_path);
     process->setArguments(arguments);
 
     process->start();

--- a/window.h
+++ b/window.h
@@ -30,7 +30,7 @@ class Window : public QDialog
     Q_OBJECT
 
   public:
-    Window();
+    Window(QString onedrive_path, QString onedrive_arguments);
 
   protected:
     void closeEvent(QCloseEvent *event) override;
@@ -47,7 +47,7 @@ class Window : public QDialog
     void createMessageGroupBox();
     void createActions();
     void createTrayIcon();
-    void execute();
+    void execute(QString onedrive_path, QString onedrive_arguments);
     void restart();
     void terminate();
     void createConfigurationGroupBox();


### PR DESCRIPTION
Available options:
  -h, --help                  Displays this help.
  -p, --onedrive-path <path>  Path to the OneDrive program
  -a, --onedrive-args <args>  Arguments passed to OneDrive

Change also default options to
- onedrive path = "onedrive" (without full path specification)
- onedrive args = "--monitor" (without --confdir etc)