### PR TITLE
Add unit file and install info

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Tested with QT 5.12.6 and 5.13.0.
 First move the binary to your path:
 
 ```
-sudo cp systray /usr/local/bin/onedrive_tray
+sudo cp onedrive_tray /usr/local/bin/onedrive_tray
 ```
 
-The execute the program:
+Then execute the program:
 
 ```
 onedrive_tray --onedrive-path [path to onedrive client] --onedrive-args [onedrive client arguments].
@@ -48,6 +48,17 @@ onedrive_tray --onedrive-path [path to onedrive client] --onedrive-args [onedriv
 
 If you want the program to execute every time you log in you can put it in the auto start scripts.
 
+You can alternatively install with make:
+
+```
+sudo make install
+```
+
+This will include a systemd service that can be enabled to auto start the application:
+
+```
+systemctl enable --user onedrive_tray.service
+```
 
 # Pre-compiled Binaries
 

--- a/onedrive_tray.service
+++ b/onedrive_tray.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=OneDrive Free Client tray icon
+Documentation=https://github.com/DanielBorgesOliveira/onedrive_tray
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/onedrive_tray
+Restart=on-failure
+RestartSec=3
+RestartPreventExitStatus=3
+
+[Install]
+WantedBy=default.target

--- a/systray.pro
+++ b/systray.pro
@@ -1,7 +1,14 @@
 TEMPLATE = app
-TARGET = systray
+TARGET = onedrive_tray
 DEPENDPATH += .
 INCLUDEPATH += .
+
+# Install info
+target.path += /usr/local/bin/
+unitfile.path += /usr/lib/systemd/user/
+unitfile.files = onedrive_tray.service
+INSTALLS += target
+INSTALLS += unitfile
 
 # Input
 HEADERS += window.h window_1.h


### PR DESCRIPTION
This adds a systemd unit file based on the one from onedrive so it can be autostarted by systemd after enabling it.