### PR TITLE
Silent fail option when no system tray is available

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -23,15 +23,21 @@ int main(int argc, char *argv[])
     QCommandLineOption onedriveArgsOption(QStringList() << "a" << "onedrive-args",
 		    "Arguments passed to OneDrive", "args");
     parser.addOption(onedriveArgsOption);
+    QCommandLineOption silentFailOption(QStringList() << "s" << "silent-fail",
+            "No error message displayed when no system tray is detected");
+    parser.addOption(silentFailOption);
 
     parser.process(app);
 
     QString onedrivePath = parser.value(onedrivePathOption);
     QString onedriveArgs = parser.value(onedriveArgsOption);
+    bool silent = parser.isSet(silentFailOption);
 
 
     if (!QSystemTrayIcon::isSystemTrayAvailable()) {
-        QMessageBox::critical(0, QObject::tr("Systray"), QObject::tr("I couldn't detect any system tray on this system."));
+        if (!silent) {
+            QMessageBox::critical(0, QObject::tr("Systray"), QObject::tr("I couldn't detect any system tray on this system."));
+        }
         return 1;
     }
     QApplication::setQuitOnLastWindowClosed(false);

--- a/onedrive_tray.service
+++ b/onedrive_tray.service
@@ -5,9 +5,9 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-ExecStart=/usr/local/bin/onedrive_tray
+ExecStart=/usr/local/bin/onedrive_tray -s
 Restart=on-failure
-RestartSec=3
+RestartSec=7
 RestartPreventExitStatus=3
 
 [Install]


### PR DESCRIPTION
To avoid showing the error message at startup I mentioned in #6