### PR TITLE
Attempt detection of dark theme and use of proper icon.

### DIFF
--- a/window.cpp
+++ b/window.cpp
@@ -329,7 +329,15 @@ void Window::createTrayIcon()
     trayIconMenu->addSeparator();
     trayIconMenu->addAction(quitAction);
 
-    trayIcon = new QSystemTrayIcon(QIcon(":/images/onedrive-blue.png"), this);
+    QString iconPath;
+    if (QPalette().color(QPalette::WindowText).value() > QPalette().color(QPalette::Window).value()) {
+        // Dark theme.
+        iconPath = ":/images/onedrive-grey.png";
+    } else {
+        iconPath = ":/images/onedrive-blue.png";
+    }
+
+    trayIcon = new QSystemTrayIcon(QIcon(/*":/images/onedrive-blue.png"*/iconPath), this);
     trayIcon->setContextMenu(trayIconMenu);
     trayIcon->show();
 


### PR DESCRIPTION
Based on the information found on https://stackoverflow.com/questions/35879025/how-to-recognize-that-an-application-is-running-in-dark-theme-on-linux I have attempted an automated detection of dark theme at program launch.

If dark theme is detected, the grey icon is used. Otherwise (light theme) the default blue icon will be used.
